### PR TITLE
Fix mine dependency

### DIFF
--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -1,0 +1,19 @@
+extends Node2D
+
+var total_gold : int
+var mines = []
+@onready var goldcounter = get_node("Camera2D/ui/gold")
+
+func _ready():
+	for i in get_children():
+		if(i.is_in_group('mine')):
+			mines.append(i)
+	print(mines.size())
+	
+func _process(delta):
+	var total = 0
+	for i in mines:
+		total += i.gold 
+	total_gold = total
+	if goldcounter != null:
+		goldcounter.text = str(total_gold)

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=9 format=3 uid="uid://bpdwilcufkl1h"]
+[gd_scene load_steps=10 format=3 uid="uid://bpdwilcufkl1h"]
 
+[ext_resource type="Script" path="res://scenes/main.gd" id="1_rg8up"]
 [ext_resource type="Script" path="res://scripts/Camera2D.gd" id="1_v04a5"]
 [ext_resource type="PackedScene" uid="uid://dlph24aphutd6" path="res://scenes/ui.tscn" id="1_yqwoj"]
 [ext_resource type="PackedScene" uid="uid://brqv464oudtwk" path="res://scenes/mine.tscn" id="2_v88sx"]
@@ -1557,6 +1558,7 @@ sources/1 = SubResource("TileSetAtlasSource_3mv42")
 sources/2 = SubResource("TileSetAtlasSource_oljeu")
 
 [node name="Main" type="Node2D"]
+script = ExtResource("1_rg8up")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(575, 323)
@@ -1579,3 +1581,9 @@ tile_set = SubResource("TileSet_20msi")
 format = 2
 layer_0/tile_data = PackedInt32Array(65537, 65537, 0, 131073, 65537, 0, 196609, 65537, 0, 196610, 65537, 0, 196611, 65537, 0, 196612, 65537, 0, 196613, 65537, 0, 196614, 65537, 0, 131078, 65537, 0, 131077, 65537, 0, 65541, 65537, 0, 65542, 65537, 0, 65540, 65537, 0, 131076, 65537, 0, 131075, 65537, 0, 65539, 65537, 0, 131074, 65537, 0, 65538, 65537, 0)
 layer_1/tile_data = PackedInt32Array()
+
+[node name="Mine2" parent="." instance=ExtResource("2_v88sx")]
+position = Vector2(714, 203)
+
+[node name="Mine3" parent="." instance=ExtResource("2_v88sx")]
+position = Vector2(286, 374)

--- a/scenes/mine.tscn
+++ b/scenes/mine.tscn
@@ -6,7 +6,7 @@
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_kqxuw"]
 size = Vector2(129, 108)
 
-[node name="Mine" type="Area2D"]
+[node name="Mine" type="Area2D" groups=["mine"]]
 position = Vector2(510, 252)
 script = ExtResource("1_hty7k")
 

--- a/scripts/mine.gd
+++ b/scripts/mine.gd
@@ -1,14 +1,17 @@
 extends Area2D
 
-var gold = 0
+var gold : int = 0
 var level = 1
 var timer : int = 0
-@onready var goldcounter =  $"../Camera2D/ui/gold"
+
+
 @onready var level_label = $Level
 @onready var time_left = $time_left
 @onready var upgrade_time = $upgrade_time
 
-
+'''
+	when left click is pressed
+'''
 func _input_event(_viewport, event, _shape_idx):
 	if event is InputEventMouseButton \
 	and event.button_index == MOUSE_BUTTON_LEFT \
@@ -24,9 +27,12 @@ func on_click():
 		timer = timer + 10
 	if level == 4 and timer < 1:
 		timer = timer + 10
+		
+	# check whether the timer is still going and if it is then stop it
 	if upgrade_time.time_left > 0:
 		upgrade_time.stop()
 	else:
+		
 		time_left.visible = true
 		upgrade_time.wait_time = timer
 		upgrade_time.start()
@@ -48,11 +54,10 @@ func _on_timer_timeout():
 		gold += 150
 	if level == 4:
 		gold += 200
-	print(gold)
-	if goldcounter != null:
-		goldcounter.text = str(gold)
-	print("timer is", timer)
-	print("level is", level)
+	print("gold : ", gold)
+	print("timer : ", timer)
+	print("level : ", level)
+	print()
 
 func _process(_delta):
 	if upgrade_time.time_left == 0:

--- a/scripts/mine.gd
+++ b/scripts/mine.gd
@@ -3,7 +3,6 @@ extends Area2D
 var gold = 0
 var level = 1
 var timer : int = 0
-@onready var ui = $"../Camera2D/ui"
 @onready var goldcounter =  $"../Camera2D/ui/gold"
 @onready var level_label = $Level
 @onready var time_left = $time_left
@@ -50,7 +49,8 @@ func _on_timer_timeout():
 	if level == 4:
 		gold += 200
 	print(gold)
-	goldcounter.text = str(gold)
+	if goldcounter != null:
+		goldcounter.text = str(gold)
 	print("timer is", timer)
 	print("level is", level)
 


### PR DESCRIPTION
This is only a temporary fix, because this is static.

when a player places a mine in the world then the counter cant pick up new mines placed by player in the world during run time because the number of mines are counted/handled in _ready(). 

it can only track all the mines placed before the scene starts so we need to handle this in the future,