### PR TITLE
fix: runtime-mines

### DIFF
--- a/scripts/TileMap.gd
+++ b/scripts/TileMap.gd
@@ -1,5 +1,6 @@
 extends TileMap
 
+signal add_mine(mine : Area2D)
 
 @onready var main = $".."
 var mine_position
@@ -7,6 +8,7 @@ var gridsize = 10
 var dictionary = {}
 var selectedtile
 var add_mines_pressed :bool = false
+var no_of_mines : int = 0
 
 
 
@@ -34,7 +36,7 @@ func MoveMouse():
 		mine_instance.position = mine_position
 		mine_instance.add_to_group("mine", true)
 		main.add_child(mine_instance)
-
+		emit_signal("add_mine", mine_instance)
 
 func _process(delta):
 	var tile = local_to_map(get_global_mouse_position())

--- a/scripts/main.gd
+++ b/scripts/main.gd
@@ -1,20 +1,31 @@
 extends Node2D
 
 var total_gold : int
-var mines = []
+var mines := []
+var no_of_mines : int
 @onready var goldcounter = get_node("Camera2D/ui/gold")
 
 func _ready():
+	get_node("TileMap").add_mine.connect(_on_tilemap_add_mine)
 	for i in get_children():
-		if(i.is_in_group('mine')):
+		if(i.is_in_group('mine') and i not in mines):
 			mines.append(i)
-	print(mines.size())
+	no_of_mines = mines.size()
 	
 func _process(delta):
 	
 	var total = 0
 	for i in mines:
-		total += i.gold 
+		total += i.gold
+		print("mine ", i, ": ", i.gold)
+	print("total: ", total)
+	print()
 	total_gold = total
 	if goldcounter != null:
 		goldcounter.text = str(total_gold)
+	#print("No of mines : ", no_of_mines)
+
+func _on_tilemap_add_mine(mine : Area2D):
+	mines.append(mine)
+	no_of_mines += 1
+	print(no_of_mines)


### PR DESCRIPTION
Fixes the total gold counter not accessing runtime mines. Now the counter identifies and uses the gold generated from mines placed in runtime and adds that to total gold counter.